### PR TITLE
Add Airtable Embed Partner Page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,27 +22,33 @@ paginate = 10
     weight = 1
 
 [[menu.main]]
+    name = "Partners"
+    identifier = "partners"
+    url  = "/partners/"
+    weight = 2
+
+[[menu.main]]
     name = "FAQ"
     identifier = "faq"
     url  = "/faq/"
-    weight = 2
+    weight = 3
 
 [[menu.main]]
     name = "Blog"
     url  = "/blog/"
     banner = "img/banners/banner-1.png"
-    weight = 3
+    weight = 4
 
 [[menu.main]]
     name = "Schedule"
     identifier = "schedule"
     url  = "/schedule/"
-    weight = 4
+    weight = 5
 
 [[menu.main]]
     name = "Contact"
     url  = "/contact/"
-    weight = 5
+    weight = 6
 
 # Top bar social links menu
 

--- a/content/partners.md
+++ b/content/partners.md
@@ -1,0 +1,11 @@
++++
+title = "Partners"
+subtitle = "We are tremendously thankful for the Partners that make DevNet possible."
+description = "DevNet Partners"
+keywords = ["partners", "partner"]
++++
+
+#### We are tremendously thankful for the Partners that make DevNet possible.
+
+
+<iframe class="airtable-embed" src="https://airtable.com/embed/shr6Z0RZ6PFqHe4fL?backgroundColor=purple" frameborder="0" onmousewheel="" width="100%" height="1000px" style="background: transparent; border: 1px solid #ccc;"></iframe>


### PR DESCRIPTION
# DO NOT MERGE
Don't merge until a deal with C-Spire has been reached

This adds a very basic AirTable embed that displays our partners on the website. This may or may not be acceptable. We'll find out.

Screenshot
![screen shot 2018-01-31 at 6 11 16 pm](https://user-images.githubusercontent.com/4278631/35654619-8afbe932-06b3-11e8-9c0c-5a251424532f.png)
