### PR TITLE
Remove Slack Button

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,12 +47,6 @@ paginate = 10
 # Top bar social links menu
 
 [[menu.topbar]]
-    weight = 1
-    name = "Slack"
-    url = "https://msstateecenter.slack.com/signup"
-    pre = "<i class='fa fa-2x fa-slack'></i>"
-
-[[menu.topbar]]
     weight = 2
     name = "GitHub"
     url = "https://github.com/devnetmsu"


### PR DESCRIPTION
Partially addresses #20 by removing the Slack link. I think we should at least take this intermediate step to reduce confusion of new members if they happen to see the old link.